### PR TITLE
Simplify routing rule proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,12 @@ Rules are processed in the order they are defined, and the first matching rule i
 
 **Configuration:**
 
-Rules are defined in the configuration file using the `routing_rules` option. Each rule is a string with the format: `type:value:action[:proxy_url]`
+Rules are defined in the configuration file using the `routing_rules` option. Each rule is a string with the format: `type:value:action[:proxy_url]`.
+When `action` is `proxy`, the optional `proxy_url` overrides the global `proxy_pass` setting. If omitted, the server uses the proxy defined by `proxy_pass`.
 
 For example:
 `routing_rules = cidr:192.168.1.0/24:direct`
-`routing_rules = domain:.google.com:proxy:socks5://myproxy.example.com:1080`
+`routing_rules = domain:.google.com:proxy`
 `routing_rules = country:CN:block`
 
 See the `doc/server.conf.example` file for more detailed examples and usage.

--- a/doc/server.conf.example
+++ b/doc/server.conf.example
@@ -20,13 +20,14 @@ auth_users=jack:1111
 # type: cidr, domain, country
 # value: CIDR string, domain pattern (exact, .suffix, *.prefix), 2-letter country code
 # action: direct, proxy, block
-# proxy_url (required for 'proxy' action): e.g., socks5://user:pass@host:port, http://host:port
+# proxy_url (optional for 'proxy' action). If omitted, use global proxy_pass. Example: socks5://user:pass@host:port
 
 # routing_rules = cidr:192.168.0.0/16:direct
 # routing_rules = domain:.internal.example.com:direct
 # routing_rules = domain:ads.example.com:block
 # routing_rules = country:CN:direct
-# routing_rules = country:US:proxy:socks5://us-proxy.example.com:1080
+# routing_rules = country:US:proxy
+# routing_rules = domain:.google.com:proxy
 # routing_rules = domain:restricted.com:block
 # routing_rules = cidr:10.1.2.3/32:proxy:http://specific-proxy.example.com:8080
 

--- a/proxy/include/proxy/proxy_server.hpp
+++ b/proxy/include/proxy/proxy_server.hpp
@@ -4983,15 +4983,19 @@ R"x*x*x(<html>
 
 			// XLOG_DBG << "Connection id: " << m_connection_id << ", Evaluating routing rules for " << destination_host << ":" << destination_port;
 
-			for (const auto& rule : rules) {
-				if (rule->matches(destination_host, destination_port, ipip_db)) {
-					// XLOG_DBG << "Connection id: " << m_connection_id << ", Matched rule. Action: " << static_cast<int>(rule->action_);
-					if (rule->action_ == RuleAction::PROXY) {
-						return std::make_pair(rule->action_, rule->get_proxy_url());
-					}
-					return std::make_pair(rule->action_, "");
-				}
-			}
+                        for (const auto& rule : rules) {
+                                if (rule->matches(destination_host, destination_port, ipip_db)) {
+                                        // XLOG_DBG << "Connection id: " << m_connection_id << ", Matched rule. Action: " << static_cast<int>(rule->action_);
+                                        if (rule->action_ == RuleAction::PROXY) {
+                                                std::string url = rule->get_proxy_url();
+                                                if (url.empty()) {
+                                                        url = m_option.proxy_pass_;
+                                                }
+                                                return std::make_pair(rule->action_, url);
+                                        }
+                                        return std::make_pair(rule->action_, "");
+                                }
+                        }
 			// XLOG_DBG << "Connection id: " << m_connection_id << ", No routing rule matched.";
 			return std::nullopt;
 		}

--- a/server/proxy_server/main.cpp
+++ b/server/proxy_server/main.cpp
@@ -233,28 +233,22 @@ start_proxy_server(net::io_context& ioc, server_ptr& server)
 		std::string proxy_url_val; 
 
 		RuleAction action_enum_val;
-		if (boost::iequals(action_str, "direct")) {
-			action_enum_val = RuleAction::DIRECT;
-		} else if (boost::iequals(action_str, "proxy")) {
-			action_enum_val = RuleAction::PROXY;
-			if (parts.size() < 4) {
-				XLOG_ERR << "Invalid rule string format for PROXY action (missing proxy_url): '" << rule_str << "'";
-				std::cerr << "Invalid rule string format for PROXY action (missing proxy_url): '" << rule_str << "'" << std::endl;
-				continue;
-			}
-			// Reconstruct proxy_url because it might contain colons
-			// The proxy_url starts after "type:value:action:"
-			size_t proxy_url_start_pos = parts[0].length() + parts[1].length() + parts[2].length() + 3;
-			if (rule_str.length() > proxy_url_start_pos) {
-				proxy_url_val = rule_str.substr(proxy_url_start_pos);
-			} else {
-				XLOG_ERR << "Proxy URL appears empty or malformed in rule: '" << rule_str << "'";
-				std::cerr << "Proxy URL appears empty or malformed in rule: '" << rule_str << "'" << std::endl;
-				continue;
-			}
-		} else if (boost::iequals(action_str, "block")) {
-			action_enum_val = RuleAction::BLOCK;
-		} else {
+                if (boost::iequals(action_str, "direct")) {
+                        action_enum_val = RuleAction::DIRECT;
+                } else if (boost::iequals(action_str, "proxy")) {
+                        action_enum_val = RuleAction::PROXY;
+                        if (parts.size() >= 4) {
+                                // Reconstruct proxy_url because it might contain colons
+                                // The proxy_url starts after "type:value:action:"
+                                size_t proxy_url_start_pos = parts[0].length() + parts[1].length() + parts[2].length() + 3;
+                                if (rule_str.length() > proxy_url_start_pos) {
+                                        proxy_url_val = rule_str.substr(proxy_url_start_pos);
+                                }
+                                // If empty, fall back to global proxy_pass at runtime
+                        }
+                } else if (boost::iequals(action_str, "block")) {
+                        action_enum_val = RuleAction::BLOCK;
+                } else {
 			XLOG_ERR << "Invalid action in rule string: '" << action_str << "' in rule: '" << rule_str << "'";
 			std::cerr << "Invalid action in rule string: '" << action_str << "' in rule: '" << rule_str << "'" << std::endl;
 			continue;

--- a/tests/test_routing_rules.cpp
+++ b/tests/test_routing_rules.cpp
@@ -42,16 +42,11 @@ std::shared_ptr<RoutingRule> parse_test_rule(const std::string& rule_str) {
         action_enum_val = RuleAction::DIRECT;
     } else if (boost::iequals(action_str, "proxy")) {
         action_enum_val = RuleAction::PROXY;
-        if (parts.size() < 4) {
-            std::cerr << "Test Parse Error: Invalid rule string format for PROXY action (missing proxy_url): '" << rule_str << "'" << std::endl;
-            return nullptr;
-        }
-        size_t proxy_url_start_pos = parts[0].length() + parts[1].length() + parts[2].length() + 3;
-        if (rule_str.length() > proxy_url_start_pos) {
-            proxy_url_val = rule_str.substr(proxy_url_start_pos);
-        } else {
-            std::cerr << "Test Parse Error: Proxy URL appears empty or malformed in rule: '" << rule_str << "'" << std::endl;
-            return nullptr;
+        if (parts.size() >= 4) {
+            size_t proxy_url_start_pos = parts[0].length() + parts[1].length() + parts[2].length() + 3;
+            if (rule_str.length() > proxy_url_start_pos) {
+                proxy_url_val = rule_str.substr(proxy_url_start_pos);
+            }
         }
     } else if (boost::iequals(action_str, "block")) {
         action_enum_val = RuleAction::BLOCK;
@@ -205,8 +200,10 @@ void test_invalid_rule_parsing() {
     // Wrong number of parts
     auto rule2 = parse_test_rule("cidr:192.168.1.0/24");
     assert(rule2 == nullptr);
-    auto rule3 = parse_test_rule("domain:example.com:proxy"); // Missing proxy_url for proxy action
-    assert(rule3 == nullptr);
+    auto rule3 = parse_test_rule("domain:example.com:proxy"); // Missing proxy_url should be allowed
+    assert(rule3 != nullptr);
+    assert(rule3->action_ == RuleAction::PROXY);
+    assert(rule3->get_proxy_url().empty());
 
     // Invalid action
     auto rule4 = parse_test_rule("cidr:192.168.1.0/24:allow");


### PR DESCRIPTION
## Summary
- allow PROXY rules to omit proxy URL when parsing
- fall back to global `proxy_pass` if a rule omits proxy URL
- update documentation and examples for optional proxy URL
- adjust unit tests accordingly

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(partial build logs shown)*
